### PR TITLE
feat(konsole): add hybrid Qt/KF6 showcase

### DIFF
--- a/.github/workflows/konsole-zig-build.yml
+++ b/.github/workflows/konsole-zig-build.yml
@@ -1,0 +1,258 @@
+name: Konsole showcase (hybrid Qt/KF6, zig)
+
+# Manual only: Qt plus the KF6 dependency graph is expensive. The preflight
+# job is deliberately separate so a bad command line or missing host package
+# fails in seconds rather than after the source graph has compiled for hours.
+on:
+  workflow_dispatch:
+    inputs:
+      konsole_ref:
+        description: 'Konsole commit (blank = the pinned commit in deps.lock)'
+        required: false
+        default: ''
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout static-everywhere
+        uses: actions/checkout@v4
+
+      - name: Install the host probe packages
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            libgl-dev libegl-dev libx11-dev libxcb1-dev libxcb-xkb-dev
+            python3-yaml
+
+      - name: Install zig 0.13.0
+        run: |
+          curl -sSL -o zig.tar.xz \
+            https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+          tar xf zig.tar.xz
+          echo "$PWD/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
+
+      - name: Build onebin for local checks
+        run: make -C onebin
+
+      - name: Fetch the pinned Konsole source for the glibc scan
+        run: |
+          KONSOLE_REF=$(awk '$1 == "konsole" { print $2 }' contrib/konsole/deps.lock)
+          git clone --filter=blob:none --quiet https://github.com/KDE/konsole.git konsole-src
+          git -C konsole-src fetch --quiet --depth 1 origin "$KONSOLE_REF"
+          git -C konsole-src checkout --quiet "$KONSOLE_REF"
+          test "$(git -C konsole-src rev-parse HEAD)" = "$KONSOLE_REF"
+
+      - name: Fast Konsole invariant checks
+        run: ./tools/preflight-konsole.sh
+
+      - name: Scan Konsole sources for newer glibc symbols
+        run: ./tools/glibc-source-scan.py konsole-src
+
+  build:
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+    steps:
+      - name: Checkout static-everywhere
+        uses: actions/checkout@v4
+
+      - name: Free disk space on the runner
+        run: |
+          echo '=== before ==='
+          df -h /
+          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                   /usr/local/.ghcup /usr/share/swift \
+                   /usr/local/share/powershell /usr/local/share/chromium \
+                   /usr/local/share/boost /opt/hostedtoolcache/CodeQL; do
+            if [ -e "$d" ]; then
+              printf '  %-8s %s\n' "$(du -sh "$d" 2>/dev/null | cut -f1)" "$d"
+              sudo rm -rf "$d" || true
+            fi
+          done
+          docker image prune -af >/dev/null 2>&1 || true
+          echo '=== after ==='
+          df -h /
+
+      - name: Install host X11/EGL/OpenGL development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            xorg-dev libx11-xcb-dev uuid-dev libegl1-mesa-dev libgl1-mesa-dev \
+            xkb-data libxkbcommon-dev libxkbcommon-x11-dev \
+            libxcb-util-dev libxcb-util0-dev libxcb-cursor-dev \
+            libxcb-dri3-dev libxcb-dri2-0-dev libxcb-present-dev \
+            libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
+            libxcb-glx0-dev libxcb-render0-dev libxcb-render-util0-dev \
+            libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev \
+            libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev \
+            libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
+            xvfb x11-utils x11-apps xdotool imagemagick ccache \
+            python3-dbus python3-yaml python3-setproctitle
+
+      - name: Build onebin
+        run: make -C onebin
+
+      - name: Download zig 0.13.0
+        run: |
+          curl -LO https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+          tar xf zig-linux-x86_64-0.13.0.tar.xz
+          echo "$PWD/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure ccache
+        run: |
+          ccache --set-config sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime,pch_defines
+          ccache --set-config base_dir="$HOME/.conan2/p/b"
+          ccache --set-config max_size=5G
+
+      - name: Restore Conan downloads, KDE metadata and ccache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.conan2/p
+            ~/.cache/ccache
+            out/konsole/sources-backup
+            out/konsole/kde-source
+            out/konsole/kde-state
+          key: konsole-zig-ccache-${{ hashFiles('tools/build-konsole.sh', 'contrib/konsole/**', 'onebin/toolchain/**') }}
+          restore-keys: |
+            konsole-zig-ccache-
+
+      - name: Fetch pinned kde-builder
+        run: |
+          KDE_BUILDER_REF=$(awk '$1 == "kde-builder" { print $2 }' contrib/konsole/deps.lock)
+          git clone --filter=blob:none --quiet https://invent.kde.org/sdk/kde-builder.git kde-builder-src
+          git -C kde-builder-src fetch --quiet --depth 1 origin "$KDE_BUILDER_REF"
+          git -C kde-builder-src checkout --quiet "$KDE_BUILDER_REF"
+          test "$(git -C kde-builder-src rev-parse HEAD)" = "$KDE_BUILDER_REF"
+
+      - name: Mark the start of this build for diagnostics
+        run: touch /tmp/job-start-marker
+
+      - name: Build Qt and KF6, then Konsole
+        run: |
+          set -o pipefail
+          KONSOLE_REF='${{ inputs.konsole_ref }}'
+          if [ -z "$KONSOLE_REF" ]; then
+            KONSOLE_REF=$(awk '$1 == "konsole" { print $2 }' contrib/konsole/deps.lock)
+          fi
+          ./tools/build-konsole.sh \
+            --out out/konsole \
+            --kde-builder "$PWD/kde-builder-src" \
+            --konsole-ref "$KONSOLE_REF" \
+            --kde-builder-ref "$(awk '$1 == "kde-builder" { print $2 }' contrib/konsole/deps.lock)" \
+            2>&1 | tee /tmp/build-output.log
+
+      - name: Run the graphical X11 smoke test
+        run: |
+          mkdir -p out/konsole/xdg-runtime
+          chmod 700 out/konsole/xdg-runtime
+          export XDG_RUNTIME_DIR="$PWD/out/konsole/xdg-runtime"
+          export KONSOLE_INSTALL_DIR="$PWD/out/konsole/kde-install"
+          ./tools/run-konsole-smoke.sh \
+            "$PWD/out/konsole/kde-install/bin/konsole" \
+            "$PWD/out/konsole/smoke"
+
+      - name: ccache statistics and disk usage
+        if: always()
+        run: |
+          ccache -s || true
+          echo '=== df -h / ==='
+          df -h /
+          echo '=== largest build stores ==='
+          du -sh "$HOME/.conan2" "$HOME/.cache/ccache" out/konsole 2>/dev/null || true
+
+      - name: Collect diagnostic logs on failure or cancellation
+        if: failure() || cancelled()
+        run: |
+          set +e
+          diag=/tmp/konsole-diagnostic-logs
+          mkdir -p "$diag"
+          cp out/konsole/konsole-audit.txt "$diag/00-konsole-audit.txt" 2>/dev/null || true
+          find "$HOME/.conan2/p/b" -newer /tmp/job-start-marker -type f \
+            ! -name '*.o' ! -name '*.a' ! -name '*.so' ! -name '*.so.*' \
+            -printf '%10s  %p\n' 2>/dev/null | sort -k2 >"$diag/01-conan-listing.txt"
+          grep -ohE 'WARN: Build folder /[^[:space:]]+' /tmp/build-output.log 2>/dev/null \
+            | sed 's|^WARN: Build folder ||' | sort -u >"$diag/02-failing-build-folders.txt"
+          if [ ! -s "$diag/02-failing-build-folders.txt" ]; then
+            find "$HOME/.conan2/p/b" out/konsole/kde-build -maxdepth 4 \
+              -type d -name 'build-*' -newer /tmp/job-start-marker \
+              2>/dev/null | tail -10 >"$diag/02-failing-build-folders.txt"
+          fi
+          find "$HOME/.conan2/p/b" out/konsole -type f \
+            -newer /tmp/job-start-marker ! -name '*.o' ! -name '*.a' \
+            ! -name '*.so' ! -name '*.so.*' -printf '%10s  %p\n' \
+            2>/dev/null | sort -k2 >"$diag/03-output-files.txt"
+          find "$HOME/.conan2/p/b" out/konsole -type f \
+            \( -name config.log -o -name CMakeError.log -o -name CMakeConfigureLog.yaml \
+               -o -name meson-log.txt -o -name LastTest.log \) \
+            -size -2M -exec cp --parents {} "$diag" \; 2>/dev/null || true
+          find "$HOME/.conan2/p/b" out/konsole/kde-build out/konsole/kde-logs \
+            -type f -newer /tmp/job-start-marker -size -2M \
+            ! -path '*/qt_sbom/*' ! -path '*/lib/cmake/*' \
+            ! -path '*_autogen.dir/*' ! -name 'cmake_install.cmake' \
+            ! -name '*.o' ! -name '*.a' ! -name '*.so' ! -name '*.so.*' \
+            2>/dev/null > /tmp/konsole-text-candidates
+          while IFS= read -r candidate; do
+            case "$(file -b --mime-type "$candidate" 2>/dev/null)" in
+              text/*|application/json|application/xml|inode/x-empty)
+                target="$diag/04-text/${candidate#/}"
+                mkdir -p "$(dirname "$target")"
+                cp "$candidate" "$target"
+                ;;
+            esac
+          done < /tmp/konsole-text-candidates
+          tail -n 3000 /tmp/build-output.log >"$diag/05-build-output-tail.txt" 2>/dev/null
+          grep -nE 'error:|ERROR|FAILED|fatal error|Traceback|undefined' \
+            /tmp/build-output.log 2>/dev/null | tail -n 500 >"$diag/06-build-errors.txt"
+          {
+            echo '=== df -h ==='; df -h
+            echo '=== free -h ==='; free -h
+            echo '=== dmesg OOM traces ==='
+            sudo dmesg 2>/dev/null | grep -iE 'killed process|out of memory|oom' || true
+          } >"$diag/07-system-state.txt"
+          du -sh "$diag" >"$diag/08-collection-size.txt" 2>&1
+
+      - name: Upload diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: konsole-zig-build-diagnostic-logs
+          path: /tmp/konsole-diagnostic-logs
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Save Conan downloads, KDE metadata and ccache
+        if: always()
+        timeout-minutes: 20
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.conan2/p
+            ~/.cache/ccache
+            out/konsole/sources-backup
+            out/konsole/kde-source
+            out/konsole/kde-state
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+      - name: Upload Konsole and graphical evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: konsole-zig-build
+          path: |
+            out/konsole/kde-install/bin/konsole
+            out/konsole/kde-install/bin/konsole.audit.txt
+            out/konsole/konsole-audit.txt
+            out/konsole/konsole-onebin-audit.txt
+            out/konsole/smoke
+            out/konsole/smoke/render.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/konsole-zig-build.yml
+++ b/.github/workflows/konsole-zig-build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-            libgl-dev libegl-dev libx11-dev libxcb1-dev libxcb-xkb-dev
+            libgl-dev libegl-dev libx11-dev libxcb1-dev libxcb-xkb-dev \
             python3-yaml
 
       - name: Install zig 0.13.0

--- a/contrib/konsole/RECIPE-AUDIT.md
+++ b/contrib/konsole/RECIPE-AUDIT.md
@@ -77,6 +77,12 @@ grep caused by the plan's inherited `PATH`, and YAML `@...@` placeholders that
 were not valid unquoted scalars. The current preflight renders the template
 and parses it, so those failures cannot reach the two-hour job silently.
 
+After the final workflow edit, the preflight package-install block received a
+separate shell-continuation audit: every package line except the final package
+has a trailing `\\`, and the two independent gates (workflow/templated YAML
+parse plus the full Konsole preflight) were rerun. No workflow dispatch is
+made until both gates pass.
+
 The remaining proof is necessarily hosted: the full Conan Qt graph, the
 source-built KF6 dependency closure, the final onebin audit, and a Konsole
 window captured from Xvfb.

--- a/contrib/konsole/RECIPE-AUDIT.md
+++ b/contrib/konsole/RECIPE-AUDIT.md
@@ -1,0 +1,82 @@
+# Konsole showcase recipe audit
+
+This file records the two pre-CI checks requested for the Konsole showcase.
+The hosted build and graphical launch are intentionally not called a success
+until the GitHub Actions job produces them.
+
+## Pass 1: f4 qt inventory
+
+The complete f4 reference was read before writing this recipe:
+
+- `.github/workflows/f4-qt-zig-build.yml`
+- `tools/build-f4-qt.sh`
+- `contrib/f4-qt/project-include.cmake`
+- `contrib/f4-qt/import-qt-static-plugins.cmake`
+- `contrib/f4-qt/optional-gl.cmake`
+- `onebin/toolchain/onebin-linux-hybrid.cmake`
+- `tools/preflight-f4-qt.sh`
+- `tools/audit-with-hygiene-waivers.sh`
+
+The load-bearing decisions were classified before adapting them:
+
+| f4 qt detail | Konsole decision |
+| --- | --- |
+| manual trigger and a separate fast preflight | carried into `konsole-zig-build.yml` |
+| runner disk cleanup, 300-minute build timeout | carried |
+| Zig 0.13.0 and onebin hybrid toolchain | carried; glibc baseline is 2.27 |
+| host X11/xcb/ICE/SM contract | carried; no host Qt or KDE package is allowed |
+| host OpenGL | carried through the existing optional-GL forwarder; `libGL` is not DT_NEEDED |
+| CMake ABI workarounds for Zig | carried: pointer size, multiarch, implicit includes and RPATH |
+| compile glibc compatibility shim before Conan | carried, with global shared/executable link flags |
+| rebuild target packages despite Conan binary availability | carried for the reduced Qt graph |
+| `PKG_CONFIG_PATH` with system multiarch paths | carried for host xcb discovery, with Conan `.pc` paths preferred during KDE build |
+| fontconfig HTTP 418 workaround | carried verbatim from f4's upstream builder |
+| source-download backup and no `conan cache clean --source` | carried |
+| ccache sloppiness/base directory/size and explicit cache save | carried |
+| `set -o pipefail` plus a saved build transcript | carried |
+| diagnostics on `failure() || cancelled()` | carried, including CMake/autotools/Meson logs, MIME-filtered text and OOM state |
+| static Qt platform/plugin registration | carried for qxcb, qxcb-GLX and qxcb-EGL; no f4 QML scanner is copied because Konsole is Widgets-only |
+| static graph assertion | carried for Qt/KF6 targets and package directories |
+| f4 Go setup, Go tests, embedded packaging and QML-specific hooks | intentionally omitted: Konsole has no Go or QML application graph |
+| f4 QWindowKit and f4 application-specific tests | intentionally omitted |
+
+The host boundary is therefore: X11/xcb and the OpenGL ABI are host-owned;
+Qt, KF6 and the application are built in the CI source graph. `qt-install-dir`
+is deliberately absent from kde-builder configuration, so kde-builder does
+not select a host or separately managed Qt tree.
+
+## Pass 2: reverse check of the Konsole recipe
+
+After the implementation was written, every item above was checked against
+the actual new workflow, build script, Conan recipe, KDE-builder template,
+CMake hook and verification scripts. The following checks were run before any
+GitHub workflow dispatch:
+
+1. `bash -n` passed for all four Konsole shell scripts.
+2. `python3 -m py_compile` passed for the Conan recipe.
+3. The rendered kde-builder YAML and workflow parsed with PyYAML; the
+   configuration has `include-dependencies: true`, `BUILD_SHARED_LIBS=OFF`,
+   `CMAKE_IGNORE_PREFIX_PATH=/usr;/lib;/lib64`, and a pinned Konsole revision.
+4. `tools/preflight-konsole.sh` passed its plan assertions, including the
+   glibc target, shim, cache preservation, static Qt options, CMake hook,
+   hygiene audit and graphical smoke command. It also verified that no Go
+   step is present.
+5. A miniature CMake project with fake static qxcb/GL plugin archives
+   configured and built successfully. It exercised the Itanium symbol parser,
+   `.prl` closure, executable-only `INTERFACE_SOURCES`, optional-GL CXX
+   compilation and static-graph assertion.
+6. `./tools/test-optional-gl-cxx-only.sh` passed.
+7. `make -C onebin test` passed: 273 tests passed and 3 were skipped by their
+   existing fixture/locale guards.
+8. The f4 reference itself was not modified. No hosted build was dispatched
+   during either pass.
+
+The reverse check also found and fixed three preflight issues before this
+record was finalized: the missing `zig-c++` plan variable, a false host-path
+grep caused by the plan's inherited `PATH`, and YAML `@...@` placeholders that
+were not valid unquoted scalars. The current preflight renders the template
+and parses it, so those failures cannot reach the two-hour job silently.
+
+The remaining proof is necessarily hosted: the full Conan Qt graph, the
+source-built KF6 dependency closure, the final onebin audit, and a Konsole
+window captured from Xvfb.

--- a/contrib/konsole/deps.lock
+++ b/contrib/konsole/deps.lock
@@ -1,0 +1,11 @@
+# contrib/konsole/deps.lock — pinned inputs for the Konsole showcase.
+# The Qt/KF6 graph is built from source; only the ABI-stable desktop contract
+# remains on the host (X11/xcb and OpenGL), exactly as in f4-qt.
+konsole 264ecd0808f752a10204f954dfc1f87f7aba9ea8 - https://github.com/KDE/konsole.git
+qt 6.11.1 - -
+icu 78.1 - -
+kde-builder 985bdc9abbffaf2fdb90e4b10392bdd6a1272ba8 - https://invent.kde.org/sdk/kde-builder.git
+conan 2.29.1 - -
+cmake 3.31.6 - -
+ninja 1.13.0 - -
+zig 0.13.0 - https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz

--- a/contrib/konsole/import-static-qt-plugins.cmake
+++ b/contrib/konsole/import-static-qt-plugins.cmake
@@ -1,0 +1,172 @@
+# static-everywhere: import the Qt platform and xcb GL plugins.
+#
+# Conan's CMakeDeps package files expose Qt's static archives but do not
+# reproduce the Q_IMPORT_PLUGIN unit that Qt's own package exports. A static
+# Widgets executable therefore builds successfully and then dies before main
+# with "Could not find the Qt platform plugin xcb". The xcb GL integrations
+# are a second, independent failure: without them a window can exist but Qt
+# cannot create the OpenGL context used to paint it.
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+    return()
+endif()
+
+function(_se_konsole_plugin_class archive out_var)
+    file(STRINGS "${archive}" _symbols REGEX "_Z[0-9]+qt_static_plugin_")
+    string(REGEX MATCH "_Z([0-9]+)qt_static_plugin_" _match "${_symbols}")
+    if(NOT _match)
+        message(FATAL_ERROR
+            "static-everywhere: ${archive} has no qt_static_plugin_<Class> "
+            "symbol; it cannot be imported as a static Qt plugin")
+    endif()
+    set(_length "${CMAKE_MATCH_1}")
+    string(FIND "${_symbols}" "${_match}" _at)
+    string(LENGTH "_Z${_length}" _prefix_length)
+    math(EXPR _at "${_at} + ${_prefix_length}")
+    string(SUBSTRING "${_symbols}" ${_at} ${_length} _full)
+    string(REPLACE "qt_static_plugin_" "" _class "${_full}")
+    if(NOT _class MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+        message(FATAL_ERROR
+            "static-everywhere: malformed plugin class '${_class}' in "
+            "${archive}; the Itanium symbol length was not parsed correctly")
+    endif()
+    set(${out_var} "${_class}" PARENT_SCOPE)
+endfunction()
+
+function(_se_konsole_prl_closure archive out_var)
+    get_filename_component(_dir "${archive}" DIRECTORY)
+    get_filename_component(_base "${archive}" NAME_WE)
+    set(_prl "${_dir}/${_base}.prl")
+    if(NOT EXISTS "${_prl}")
+        message(FATAL_ERROR
+            "static-everywhere: ${_prl} is missing. Qt's .prl is the source "
+            "of truth for a static plugin's backing-library closure")
+    endif()
+
+    file(STRINGS "${_prl}" _line REGEX "^QMAKE_PRL_LIBS[ \\t]*=")
+    if(NOT _line)
+        set(${out_var} "" PARENT_SCOPE)
+        return()
+    endif()
+    string(REGEX REPLACE "^QMAKE_PRL_LIBS[ \\t]*=[ \\t]*" "" _libs "${_line}")
+    set(_qt_prefix "${qt_PACKAGE_FOLDER_RELEASE}")
+    if(NOT _qt_prefix)
+        set(_qt_prefix "${Qt6_PACKAGE_FOLDER_RELEASE}")
+    endif()
+    if(NOT _qt_prefix OR _qt_prefix MATCHES "^/(usr|lib)(/|$)")
+        message(FATAL_ERROR
+            "static-everywhere: Qt package folder is missing or host-owned: "
+            "'${_qt_prefix}'")
+    endif()
+    string(REPLACE "$$[QT_INSTALL_PREFIX]" "${_qt_prefix}" _libs "${_libs}")
+    string(REPLACE "$$[QT_INSTALL_LIBS]" "${_qt_prefix}/lib" _libs "${_libs}")
+    string(REPLACE "$$[QT_INSTALL_PLUGINS]" "${_qt_prefix}/plugins" _libs "${_libs}")
+    string(REPLACE "$$[QT_INSTALL_ARCHDATA]" "${_qt_prefix}" _libs "${_libs}")
+    if(_libs MATCHES "\\$\\$\\[([A-Z_]+)\\]")
+        message(FATAL_ERROR
+            "static-everywhere: unhandled qmake token in ${_prl}: "
+            "$$[${CMAKE_MATCH_1}]")
+    endif()
+
+    # Conan may leave its build-time target names in QMAKE_PRL_LIBS. They are
+    # not paths and must not become CMake target references unless that target
+    # actually exists. Qt's component interface already carries these Conan
+    # libraries; retaining an unknown :: token makes generation fail.
+    string(REGEX REPLACE "/[^ ;]*/p/lib/" "${_qt_prefix}/lib/" _libs "${_libs}")
+    separate_arguments(_items UNIX_COMMAND "${_libs}")
+    set(_result "")
+    foreach(_item IN LISTS _items)
+        string(REGEX REPLACE "^-l" "" _bare "${_item}")
+        if(_bare MATCHES "::" AND NOT TARGET "${_bare}")
+            continue()
+        endif()
+        if(_item MATCHES "^/" AND NOT EXISTS "${_item}")
+            continue()
+        endif()
+        list(APPEND _result "${_item}")
+    endforeach()
+    set(${out_var} "${_result}" PARENT_SCOPE)
+endfunction()
+
+function(_se_konsole_import_one archive imports_var libs_var)
+    _se_konsole_plugin_class("${archive}" _class)
+    _se_konsole_prl_closure("${archive}" _closure)
+    string(APPEND _imports "Q_IMPORT_PLUGIN(${_class})\n")
+    set(_new_libs "${archive}")
+    list(APPEND _new_libs ${_closure})
+    set(${imports_var} "${${imports_var}}${_imports}" PARENT_SCOPE)
+    set(${libs_var} ${${libs_var}} ${_new_libs} PARENT_SCOPE)
+endfunction()
+
+function(_se_konsole_import_static_qt_plugins)
+    if(NOT TARGET Qt6::Core OR NOT TARGET Qt6::Gui)
+        message(FATAL_ERROR
+            "static-everywhere: Qt6::Core and Qt6::Gui must exist before "
+            "Konsole's static plugin hook runs")
+    endif()
+    get_target_property(_core_type Qt6::Core TYPE)
+    if(_core_type STREQUAL "SHARED_LIBRARY")
+        message(FATAL_ERROR
+            "static-everywhere: Konsole was configured with shared Qt; the "
+            "showcase requires Conan's static Qt graph")
+    endif()
+
+    set(_qt_prefix "${qt_PACKAGE_FOLDER_RELEASE}")
+    if(NOT _qt_prefix)
+        set(_qt_prefix "${Qt6_PACKAGE_FOLDER_RELEASE}")
+    endif()
+    if(NOT _qt_prefix OR _qt_prefix MATCHES "^/(usr|lib)(/|$)")
+        message(FATAL_ERROR
+            "static-everywhere: Qt6 package folder is not a non-host path: "
+            "'${_qt_prefix}'")
+    endif()
+
+    set(_imports "")
+    set(_libs "")
+    foreach(_entry
+            platforms/qxcb
+            xcbglintegrations/qxcb-glx-integration
+            xcbglintegrations/qxcb-egl-integration)
+        get_filename_component(_dir "${_entry}" DIRECTORY)
+        get_filename_component(_name "${_entry}" NAME)
+        unset(_archive CACHE)
+        unset(_archive)
+        find_library(_archive NAMES "${_name}"
+            PATHS "${_qt_prefix}/plugins/${_dir}" NO_DEFAULT_PATH)
+        if(NOT _archive)
+            message(FATAL_ERROR
+                "static-everywhere: required Qt static plugin archive "
+                "plugins/${_entry}/lib${_name}.a is missing")
+        endif()
+        if(NOT _archive MATCHES "\\.a$")
+            message(FATAL_ERROR
+                "static-everywhere: Qt plugin ${_entry} resolved to a shared "
+                "object (${_archive}); the showcase requires static Qt")
+        endif()
+        _se_konsole_import_one("${_archive}" _imports _libs)
+    endforeach()
+
+    # Conan declares this component on some Qt versions. Keeping it in the
+    # interface is harmless and preserves any dependency metadata the recipe
+    # does know about, while the archive above guarantees the actual import.
+    if(TARGET Qt6::QXcbIntegrationPlugin)
+        list(APPEND _libs Qt6::QXcbIntegrationPlugin)
+    endif()
+
+    set(_generated "${CMAKE_BINARY_DIR}/static_everywhere_konsole_qt_plugins.cpp")
+    file(GENERATE OUTPUT "${_generated}" CONTENT
+        "// Generated by static-everywhere; do not edit.\n#include <QtPlugin>\n${_imports}")
+    # The generated source is for executables only. Unrestricted
+    # INTERFACE_SOURCES would put the registration unit into intermediate
+    # static libraries and can create both duplicate registrations and a
+    # CMake dependency cycle.
+    set_property(TARGET Qt6::Gui APPEND PROPERTY INTERFACE_SOURCES
+        "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:${_generated}>")
+    set_property(TARGET Qt6::Gui APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${_libs})
+    message(STATUS
+        "static-everywhere: imported qxcb, qxcb-glx-integration and "
+        "qxcb-egl-integration into Qt6::Gui")
+endfunction()
+
+cmake_language(DEFER DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+               CALL _se_konsole_import_static_qt_plugins)

--- a/contrib/konsole/kde-builder.yaml.in
+++ b/contrib/konsole/kde-builder.yaml.in
@@ -1,0 +1,45 @@
+config-version: 2
+
+global:
+  branch-group: latest-kf6
+  include-dependencies: true
+  source-dir: "@KDE_SOURCE_DIR@"
+  build-dir: "@KDE_BUILD_DIR@"
+  install-dir: "@KDE_INSTALL_DIR@"
+  log-dir: "@KDE_LOG_DIR@"
+  persistent-data-file: "@KDE_STATE_DIR@/persistent.json"
+  cmake-generator: Ninja
+  stop-on-failure: true
+  run-tests: false
+  check-self-updates: false
+  compile-commands-export: false
+  compile-commands-linking: false
+  num-cores: "@KDE_JOBS@"
+  cmake-options: >
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_TOOLCHAIN_FILE=@CONAN_TOOLCHAIN@
+    -DCMAKE_C_COMPILER=@ZIGCC@
+    -DCMAKE_CXX_COMPILER=@ZIGCXX@
+    -DCMAKE_PREFIX_PATH=@CMAKE_PREFIX_PATH@
+    -DCMAKE_PROJECT_INCLUDE=@PROJECT_INCLUDE@
+    -DBUILD_SHARED_LIBS=OFF
+    -DCMAKE_SKIP_RPATH=ON
+    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF
+    -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON
+    -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF
+    -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF
+    -DCMAKE_IGNORE_PREFIX_PATH=/usr;/lib;/lib64
+    -DKDE_INSTALL_USE_QT_SYS_PATHS=OFF
+    -DONEBIN_GLIBC_BASELINE=2.27
+    -DBUILD_TESTING=OFF
+    -DUSE_DBUS=OFF
+    -DWITH_KAPSULE=OFF
+    -DWITH_LIBSSH=OFF
+    -DWITH_X11=ON
+    -DENABLE_PLUGIN_SSHMANAGER=OFF
+    -DENABLE_PLUGIN_QUICKCOMMANDS=OFF
+    -DKONSOLE_BUILD_UNI2CHARACTERWIDTH=OFF
+    -DINSTALL_ICONS=ON
+
+override konsole:
+  revision: "@KONSOLE_REF@"

--- a/contrib/konsole/project-include.cmake
+++ b/contrib/konsole/project-include.cmake
@@ -1,0 +1,79 @@
+# static-everywhere: the one CMAKE_PROJECT_INCLUDE hook for Konsole.
+if(NOT PROJECT_IS_TOP_LEVEL)
+    return()
+endif()
+
+if(NOT PROJECT_NAME STREQUAL "konsole")
+    return()
+endif()
+
+get_filename_component(_SE_REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+include("${CMAKE_CURRENT_LIST_DIR}/import-static-qt-plugins.cmake")
+
+# This is deliberately the f4 implementation, not a new GL policy. It
+# removes libGL from DT_NEEDED and loads the host OpenGL implementation at
+# runtime; X11 remains a normal host dependency. Widgets does not use the
+# Quick fallback path, but the constructor is harmless and keeps the same
+# host-OpenGL behavior as the reference recipe.
+include("${_SE_REPO_ROOT}/contrib/f4-qt/optional-gl.cmake")
+
+function(_se_konsole_assert_static_graph)
+    set(_qt_components Core Gui Multimedia PrintSupport Widgets Xml)
+    foreach(_component IN LISTS _qt_components)
+        if(TARGET "Qt6::${_component}")
+            get_target_property(_type "Qt6::${_component}" TYPE)
+            if(NOT _type STREQUAL "STATIC_LIBRARY" AND
+               NOT _type STREQUAL "INTERFACE_LIBRARY" AND
+               NOT _type STREQUAL "OBJECT_LIBRARY")
+                message(FATAL_ERROR
+                    "static-everywhere: Qt6::${_component} is ${_type}; "
+                    "host/shared Qt is forbidden")
+            endif()
+        endif()
+    endforeach()
+
+    set(_kf_components Bookmarks BookmarksWidgets ConfigCore ConfigWidgets
+        CoreAddons Crash GuiAddons I18n IconThemes IconWidgets KIOWidgets
+        NewStuffCore NewStuffWidgets Notifications NotifyConfig Parts Pty
+        Service TextWidgets WindowSystem XmlGui)
+    foreach(_component IN LISTS _kf_components)
+        if(TARGET "KF6::${_component}")
+            get_target_property(_type "KF6::${_component}" TYPE)
+            if(NOT _type STREQUAL "STATIC_LIBRARY" AND
+               NOT _type STREQUAL "INTERFACE_LIBRARY" AND
+               NOT _type STREQUAL "OBJECT_LIBRARY")
+                message(FATAL_ERROR
+                    "static-everywhere: KF6::${_component} is ${_type}; "
+                    "host/shared KDE Frameworks are forbidden")
+            endif()
+        endif()
+    endforeach()
+
+    foreach(_target Qt6::Core Qt6::Gui Qt6::Multimedia Qt6::PrintSupport
+                    Qt6::Widgets KF6::CoreAddons KF6::ConfigCore KF6::I18n
+                    KF6::KIOCore KF6::KIOWidgets KF6::WindowSystem)
+        if(TARGET "${_target}")
+            foreach(_location_property IMPORTED_LOCATION_RELEASE IMPORTED_LOCATION)
+                get_target_property(_location "${_target}" "${_location_property}")
+                if(_location AND "${_location}" MATCHES "^/(usr|lib)(/|$)")
+                    message(FATAL_ERROR
+                        "static-everywhere: ${_target} imports a host library "
+                        "from ${_location}")
+                endif()
+            endforeach()
+        endif()
+    endforeach()
+
+    foreach(_var Qt6_DIR ECM_DIR KF6_DIR KF6Config_DIR KF6CoreAddons_DIR
+                    KF6I18n_DIR KF6KIO_DIR ICU_DIR)
+        if(DEFINED ${_var} AND "${${_var}}" MATCHES "^/(usr|lib)(/|$)")
+            message(FATAL_ERROR
+                "static-everywhere: ${_var} resolves to the host path "
+                "${${_var}}")
+        endif()
+    endforeach()
+    message(STATUS "static-everywhere: Qt/KF6 graph is non-host and static")
+endfunction()
+
+cmake_language(DEFER DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+               CALL _se_konsole_assert_static_graph)

--- a/contrib/konsole/qt-host/conanfile.py
+++ b/contrib/konsole/qt-host/conanfile.py
@@ -1,0 +1,68 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeDeps, CMakeToolchain
+
+
+class KonsoleQtHostConan(ConanFile):
+    name = "static-everywhere-konsole-qt-host"
+    version = "0.1"
+    settings = "os", "compiler", "build_type", "arch"
+
+    # This is intentionally a small Qt surface. Konsole is a Widgets
+    # application; QML, Qt Quick, Wayland, DBus and the multimedia backends
+    # are not part of the showcase. qtmultimedia itself is required by
+    # Konsole, but its optional audio backends are not.
+    default_options = {
+        "qt/*:shared": False,
+        "qt/*:opengl": "desktop",
+        "qt/*:qtmultimedia": True,
+        "qt/*:qtdeclarative": False,
+        "qt/*:qtimageformats": False,
+        "qt/*:qtshadertools": False,
+        "qt/*:qttools": False,
+        "qt/*:qttranslations": False,
+        "qt/*:qtwayland": False,
+        "qt/*:with_dbus": False,
+        "qt/*:with_egl": True,
+        "qt/*:with_x11": True,
+        "qt/*:with_glib": False,
+        "qt/*:with_openal": False,
+        "qt/*:with_gstreamer": False,
+        "qt/*:with_pulseaudio": False,
+        "qt/*:with_libalsa": False,
+        "qt/*:with_icu": True,
+        "qt/*:with_fontconfig": True,
+        "qt/*:with_freetype": True,
+        "qt/*:with_harfbuzz": True,
+        "qt/*:with_libpng": True,
+        "qt/*:with_pq": False,
+        "qt/*:with_odbc": False,
+        "qt/*:with_sqlite3": False,
+        "qt/*:with_vulkan": False,
+        "qt/*:openssl": False,
+        "qt/*:with_gssapi": False,
+        "qt/*:with_zstd": False,
+        "xkbcommon/*:with_x11": True,
+        "xkbcommon/*:with_wayland": False,
+    }
+
+    # Konsole's CMakeLists.txt asks for ICU directly, not only through Qt.
+    # Keeping it a direct requirement makes CMakeDeps publish ICU::uc and
+    # ICU::i18n and prevents a host ICU installation from satisfying it.
+    requires = ("qt/6.11.1", "icu/78.1")
+
+    def generate(self):
+        CMakeDeps(self).generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["CMAKE_BUILD_TYPE"] = "Release"
+        # zig-cc cannot complete CMake's ABI probe, although this target is
+        # unambiguously x86_64. These are the same values forced in f4 qt.
+        tc.variables["CMAKE_SIZEOF_VOID_P"] = "8"
+        tc.variables["CMAKE_LIBRARY_ARCHITECTURE"] = "x86_64-linux-gnu"
+        tc.variables["CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES"] = "/usr/include"
+        tc.variables["CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES"] = "/usr/include"
+        tc.variables["CMAKE_SKIP_RPATH"] = True
+        tc.variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        tc.variables["CMAKE_FIND_USE_PACKAGE_REGISTRY"] = False
+        tc.variables["CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY"] = False
+        tc.generate()

--- a/tools/build-konsole.sh
+++ b/tools/build-konsole.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Build the Konsole showcase with static Conan Qt and source-built KF6.
+# Host dependencies are limited to X11/xcb and the OpenGL ABI, as in f4 qt.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+ONEBIN_BIN="$REPO_ROOT/onebin/build/onebin"
+ZIGCC="$REPO_ROOT/onebin/toolchain/zig-cc"
+ZIGCXX="$REPO_ROOT/onebin/toolchain/zig-c++"
+GLIBC_BASELINE=2.27
+KONSOLE_REF=264ecd0808f752a10204f954dfc1f87f7aba9ea8
+KDE_BUILDER_REF=985bdc9abbffaf2fdb90e4b10392bdd6a1272ba8
+OUT=./out/konsole
+KDE_BUILDER=
+PRINT_PLAN=0
+
+usage() {
+    cat <<'EOF'
+Usage: tools/build-konsole.sh --kde-builder DIR [OPTIONS]
+
+  --kde-builder DIR       checked-out kde-builder source tree
+  --out DIR               output directory (default: ./out/konsole)
+  --konsole-ref SHA       Konsole commit (default: pinned showcase commit)
+  --kde-builder-ref SHA   kde-builder commit (default: pinned showcase commit)
+  --print-plan            print every build command without executing it
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --kde-builder) KDE_BUILDER=${2:-}; shift 2 ;;
+        --out) OUT=${2:-}; shift 2 ;;
+        --konsole-ref) KONSOLE_REF=${2:-}; shift 2 ;;
+        --kde-builder-ref) KDE_BUILDER_REF=${2:-}; shift 2 ;;
+        --print-plan) PRINT_PLAN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'error: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z $KDE_BUILDER ]]; then
+    printf 'error: --kde-builder is required\n' >&2
+    exit 2
+fi
+if [[ $OUT = /* ]]; then
+    OUT_ABS=$OUT
+else
+    OUT_ABS=$(pwd)/${OUT#./}
+fi
+if [[ -d $KDE_BUILDER ]]; then
+    KDE_BUILDER=$(cd -- "$KDE_BUILDER" && pwd)
+fi
+
+KDE_SOURCE_DIR="$OUT_ABS/kde-source"
+KDE_BUILD_DIR="$OUT_ABS/kde-build"
+KDE_INSTALL_DIR="$OUT_ABS/kde-install"
+KDE_LOG_DIR="$OUT_ABS/kde-logs"
+KDE_STATE_DIR="$OUT_ABS/kde-state"
+QT_OUT="$OUT_ABS/qt"
+CONAN_VENV="$OUT_ABS/conan-venv"
+CONAN_HOME=${CONAN_HOME:-$HOME/.conan2}
+KDE_JOBS=${KONSOLE_JOBS:-$(nproc)}
+KDE_CONFIG="$OUT_ABS/kde-builder.yaml"
+CONAN_TOOLCHAIN="$QT_OUT/conan_toolchain.cmake"
+CMAKE_PREFIX_PATH="$QT_OUT;$KDE_INSTALL_DIR"
+TARGET_TRIPLE="x86_64-linux-gnu.${GLIBC_BASELINE}"
+GIT_CONFIG_GLOBAL="$OUT_ABS/gitconfig"
+
+quote_cmd() {
+    printf '+ '
+    printf '%q ' "$@"
+    printf '\n'
+}
+run() {
+    if [[ $PRINT_PLAN -eq 1 ]]; then
+        quote_cmd "$@"
+    else
+        quote_cmd "$@" >&2
+        "$@"
+    fi
+}
+run_env() {
+    if [[ $PRINT_PLAN -eq 1 ]]; then
+        quote_cmd env "$@"
+    else
+        quote_cmd env "$@" >&2
+        env "$@"
+    fi
+}
+
+printf '# Konsole showcase plan\n'
+printf 'konsole_ref=%s\nkde_builder_ref=%s\nglibc_baseline=%s\n' \
+    "$KONSOLE_REF" "$KDE_BUILDER_REF" "$GLIBC_BASELINE"
+printf 'host contract: X11/xcb/ICE/SM and runtime-loaded OpenGL; Qt/KF6: source-built\n'
+while IFS=' ' read -r name version _hash url; do
+    [[ -z $name || $name == \#* ]] && continue
+    printf '# dependency: %s %s\n' "$name" "$version"
+done < "$REPO_ROOT/contrib/konsole/deps.lock"
+
+if [[ $PRINT_PLAN -eq 0 ]]; then
+    [[ -x $ONEBIN_BIN ]] || { printf 'error: build onebin first\n' >&2; exit 1; }
+    command -v zig >/dev/null || { printf 'error: zig is not on PATH\n' >&2; exit 1; }
+    command -v uv >/dev/null || { printf 'error: uv is not on PATH\n' >&2; exit 1; }
+    [[ -f "$KDE_BUILDER/kde-builder" ]] || {
+        printf 'error: kde-builder source tree is missing %s/kde-builder\n' "$KDE_BUILDER" >&2
+        exit 1
+    }
+    actual_kde_builder=$(git -C "$KDE_BUILDER" rev-parse HEAD)
+    [[ $actual_kde_builder == "$KDE_BUILDER_REF" ]] || {
+        printf 'error: kde-builder is %s, expected %s\n' "$actual_kde_builder" "$KDE_BUILDER_REF" >&2
+        exit 1
+    }
+fi
+
+run mkdir -p "$OUT_ABS" "$QT_OUT" "$KDE_SOURCE_DIR" "$KDE_BUILD_DIR" \
+    "$KDE_INSTALL_DIR" "$KDE_LOG_DIR" "$KDE_STATE_DIR"
+run touch "$GIT_CONFIG_GLOBAL"
+run "$ZIGCC" -target "$TARGET_TRIPLE" -O2 -fPIC -c \
+    "$REPO_ROOT/contrib/f4-qt/compat/glibc-shims.c" \
+    -o "$OUT_ABS/compat-glibc-shims.o"
+
+run mkdir -p "$CONAN_VENV"
+run uv venv --python 3.12 --clear "$CONAN_VENV"
+run uv pip install --python "$CONAN_VENV/bin/python" \
+    conan==2.29.1 cmake==3.31.6 ninja==1.13.0
+run_env PATH="$CONAN_VENV/bin:$PATH" CONAN_HOME="$CONAN_HOME" \
+    conan profile detect --force
+
+# This is f4's exact fontconfig transport workaround. The runner may receive
+# HTTP 418 from freedesktop.org; the Conan checksum remains authoritative.
+run_env PATH="$CONAN_VENV/bin:$PATH" CONAN_HOME="$CONAN_HOME" \
+    conan download fontconfig/2.15.0 --only-recipe --remote=conancenter
+if [[ $PRINT_PLAN -eq 1 ]]; then
+    quote_cmd bash -c 'fontconfig_recipe=$(conan cache path fontconfig/2.15.0); copy=$(mktemp -d /tmp/static-everywhere-fontconfig.XXXXXX); cp "$fontconfig_recipe/conanfile.py" "$fontconfig_recipe/conandata.yml" "$copy/"; sed -i "s#https://www.freedesktop.org/software/fontconfig/release/#https://distfiles.macports.org/fontconfig/#" "$copy/conandata.yml"; grep -q "https://distfiles.macports.org/fontconfig/fontconfig-2.15.0.tar.xz" "$copy/conandata.yml"; conan export "$copy" --name=fontconfig --version=2.15.0'
+else
+    fontconfig_recipe=$(env PATH="$CONAN_VENV/bin:$PATH" CONAN_HOME="$CONAN_HOME" \
+        conan cache path fontconfig/2.15.0)
+    fontconfig_copy=$(mktemp -d /tmp/static-everywhere-fontconfig.XXXXXX)
+    cp "$fontconfig_recipe/conanfile.py" "$fontconfig_recipe/conandata.yml" "$fontconfig_copy/"
+    sed -i 's#https://www.freedesktop.org/software/fontconfig/release/#https://distfiles.macports.org/fontconfig/#' \
+        "$fontconfig_copy/conandata.yml"
+    grep -q 'https://distfiles.macports.org/fontconfig/fontconfig-2.15.0.tar.xz' \
+        "$fontconfig_copy/conandata.yml"
+    run_env PATH="$CONAN_VENV/bin:$PATH" CONAN_HOME="$CONAN_HOME" \
+        conan export "$fontconfig_copy" --name=fontconfig --version=2.15.0
+fi
+
+# Conan package IDs do not include the glibc baseline, so every native target
+# package in the graph is rebuilt instead of silently taking a GCC binary.
+conan_args=(
+    install "$REPO_ROOT/contrib/konsole/qt-host"
+    --build=missing
+    --build='brotli/*' --build='bzip2/*' --build='double-conversion/*'
+    --build='expat/*' --build='fontconfig/*' --build='freetype/*'
+    --build='harfbuzz/*' --build='icu/*' --build='libffi/*'
+    --build='libiconv/*' --build='libpng/*' --build='md4c/*'
+    --build='pcre2/*' --build='qt/*' --build='xkbcommon/*'
+    --build='xz_utils/*' --build='zlib/*'
+    -s:h build_type=Release -s:h compiler.cppstd=gnu20
+    -s:b build_type=Release -s:b compiler.cppstd=gnu20
+    -o:h 'qt/*:shared=False' -o:h 'qt/*:opengl=desktop'
+    -o:h 'qt/*:qtmultimedia=True' -o:h 'qt/*:qtwayland=False'
+    -o:h 'qt/*:with_egl=True' -o:h 'qt/*:with_x11=True'
+    -o:h 'qt/*:with_glib=False' -o:h 'qt/*:with_openal=False'
+    -o:h 'qt/*:with_gstreamer=False' -o:h 'qt/*:with_pulseaudio=False'
+    -o:h 'qt/*:with_libalsa=False' -o:h 'qt/*:with_dbus=False'
+    -o:h 'qt/*:openssl=False' -o:h 'xkbcommon/*:with_x11=True'
+    -o:h 'xkbcommon/*:with_wayland=False'
+    -c "tools.build:compiler_executables={\"c\":\"$ZIGCC\",\"cpp\":\"$ZIGCXX\"}"
+    -c 'tools.cmake.cmaketoolchain:extra_variables={"CMAKE_C_COMPILER_LAUNCHER":"ccache","CMAKE_CXX_COMPILER_LAUNCHER":"ccache","CMAKE_SIZEOF_VOID_P":"8","CMAKE_LIBRARY_ARCHITECTURE":"x86_64-linux-gnu","CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES":"/usr/include","CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES":"/usr/include","CMAKE_SKIP_RPATH":"ON","CMAKE_FIND_PACKAGE_PREFER_CONFIG":"ON"}'
+    -c "tools.build:cflags=[\"-target\",\"$TARGET_TRIPLE\"]"
+    -c "tools.build:cxxflags=[\"-target\",\"$TARGET_TRIPLE\"]"
+    -c "tools.build:sharedlinkflags=[\"-target\",\"$TARGET_TRIPLE\",\"$OUT_ABS/compat-glibc-shims.o\",\"-Wl,--strip-debug\"]"
+    -c "tools.build:exelinkflags=[\"-target\",\"$TARGET_TRIPLE\",\"-pie\",\"$OUT_ABS/compat-glibc-shims.o\",\"-Wl,--strip-debug\"]"
+    -cc "core.sources:download_cache=$OUT_ABS/sources-backup"
+    -cc 'core.sources:download_urls=["https://c3i.jfrog.io/artifactory/conan-center-backup-sources/","origin"]'
+    -c tools.system.package_manager:mode=check
+    -vv --output-folder="$QT_OUT"
+)
+run_env PATH="$CONAN_VENV/bin:$PATH" \
+    PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH:-}" \
+    CONAN_HOME="$CONAN_HOME" conan "${conan_args[@]}"
+run_env PATH="$CONAN_VENV/bin:$PATH" CONAN_HOME="$CONAN_HOME" \
+    conan cache clean '*' --build --temp
+
+if [[ $PRINT_PLAN -eq 1 ]]; then
+    quote_cmd bash -c 'pc_dirs=$(find "$CONAN_HOME/p/b" -type f -name "*.pc" -printf "%h\\n" 2>/dev/null | sort -u | paste -sd: -); export PKG_CONFIG_PATH="$pc_dirs:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH:-}"; pkg-config --modversion xkbcommon'
+else
+    pc_dirs=$(find "$CONAN_HOME/p/b" -type f -name '*.pc' -printf '%h\n' 2>/dev/null | sort -u | paste -sd: -)
+    export PKG_CONFIG_PATH="$pc_dirs:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH:-}"
+    pkg-config --modversion xkbcommon || {
+        printf 'warning: Conan xkbcommon .pc file was not found; do not accept a host xkbcommon fallback silently\n' >&2
+    }
+fi
+
+render_config() {
+    sed -e "s|@KDE_SOURCE_DIR@|$KDE_SOURCE_DIR|g" \
+        -e "s|@KDE_BUILD_DIR@|$KDE_BUILD_DIR|g" \
+        -e "s|@KDE_INSTALL_DIR@|$KDE_INSTALL_DIR|g" \
+        -e "s|@KDE_LOG_DIR@|$KDE_LOG_DIR|g" \
+        -e "s|@KDE_STATE_DIR@|$KDE_STATE_DIR|g" \
+        -e "s|@KDE_JOBS@|$KDE_JOBS|g" \
+        -e "s|@CONAN_TOOLCHAIN@|$CONAN_TOOLCHAIN|g" \
+        -e "s|@ZIGCC@|$ZIGCC|g" \
+        -e "s|@ZIGCXX@|$ZIGCXX|g" \
+        -e "s|@CMAKE_PREFIX_PATH@|$CMAKE_PREFIX_PATH|g" \
+        -e "s|@PROJECT_INCLUDE@|$REPO_ROOT/contrib/konsole/project-include.cmake|g" \
+        -e "s|@KONSOLE_REF@|$KONSOLE_REF|g" \
+        "$REPO_ROOT/contrib/konsole/kde-builder.yaml.in"
+}
+if [[ $PRINT_PLAN -eq 1 ]]; then
+    quote_cmd bash -c "rendered config > $KDE_CONFIG"
+else
+    render_config >"$KDE_CONFIG"
+fi
+
+run_env GIT_CONFIG_GLOBAL="$GIT_CONFIG_GLOBAL" PYTHONPATH="$KDE_BUILDER" \
+    XDG_STATE_HOME="$KDE_STATE_DIR" \
+    CC="$ZIGCC" CXX="$ZIGCXX" \
+    PATH="$CONAN_VENV/bin:$PATH" python3 "$KDE_BUILDER/kde-builder" \
+    --rc-file "$KDE_CONFIG" konsole
+
+KONSOLE_BIN="$KDE_INSTALL_DIR/bin/konsole"
+if [[ $PRINT_PLAN -eq 1 ]]; then
+    quote_cmd "$REPO_ROOT/tools/verify-konsole-artifact.sh" "$KONSOLE_BIN"
+    quote_cmd "$REPO_ROOT/tools/audit-with-hygiene-waivers.sh" "$ONEBIN_BIN" \
+        --profile hybrid --glibc-max "$GLIBC_BASELINE" \
+        --allow libc.so.6 --allow libdl.so.2 --allow libpthread.so.0 \
+        --allow libX11.so.6 --allow libX11-xcb.so.1 --allow libxcb.so.1 \
+        --allow libxcb-cursor.so.0 --allow libxcb-icccm.so.4 \
+        --allow libxcb-image.so.0 --allow libxcb-keysyms.so.1 \
+        --allow libxcb-randr.so.0 --allow libxcb-render.so.0 \
+        --allow libxcb-render-util.so.0 --allow libxcb-shape.so.0 \
+        --allow libxcb-shm.so.0 --allow libxcb-sync.so.1 \
+        --allow libxcb-xfixes.so.0 --allow libxcb-xkb.so.1 \
+        --allow libICE.so.6 --allow libSM.so.6 --level 1 --strict "$KONSOLE_BIN"
+else
+    [[ -x $KONSOLE_BIN ]] || { printf 'error: kde-builder did not install %s\n' "$KONSOLE_BIN" >&2; exit 1; }
+    "$REPO_ROOT/tools/verify-konsole-artifact.sh" "$KONSOLE_BIN" | tee "$OUT_ABS/konsole-audit.txt"
+    audit_args=(
+        --profile hybrid --glibc-max "$GLIBC_BASELINE"
+        --allow libc.so.6 --allow libdl.so.2 --allow libpthread.so.0
+        --allow libX11.so.6 --allow libX11-xcb.so.1 --allow libxcb.so.1
+        --allow libxcb-cursor.so.0 --allow libxcb-icccm.so.4
+        --allow libxcb-image.so.0 --allow libxcb-keysyms.so.1
+        --allow libxcb-randr.so.0 --allow libxcb-render.so.0
+        --allow libxcb-render-util.so.0 --allow libxcb-shape.so.0
+        --allow libxcb-shm.so.0 --allow libxcb-sync.so.1
+        --allow libxcb-xfixes.so.0 --allow libxcb-xkb.so.1
+        --allow libICE.so.6 --allow libSM.so.6 --level 1 --strict "$KONSOLE_BIN"
+    )
+    "$REPO_ROOT/tools/audit-with-hygiene-waivers.sh" "$ONEBIN_BIN" "${audit_args[@]}" \
+        | tee "$OUT_ABS/konsole-onebin-audit.txt"
+fi
+printf 'Konsole build output: %s\n' "$OUT_ABS"

--- a/tools/preflight-konsole.sh
+++ b/tools/preflight-konsole.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Fast, no-build assertions for the Konsole workflow.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+PLAN=$(mktemp)
+RENDERED=$(mktemp)
+trap 'rm -f "$PLAN" "$RENDERED"' EXIT
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$1"; }
+
+bash -n "$REPO_ROOT/tools/build-konsole.sh" "$REPO_ROOT/tools/preflight-konsole.sh" \
+    "$REPO_ROOT/tools/run-konsole-smoke.sh" "$REPO_ROOT/tools/verify-konsole-artifact.sh"
+pass 'Konsole shell scripts parse'
+
+"$REPO_ROOT/tools/build-konsole.sh" --kde-builder "$REPO_ROOT" --print-plan >"$PLAN" || \
+    fail '--print-plan failed'
+
+for needle in \
+    'x86_64-linux-gnu.2.27' \
+    'CMAKE_SIZEOF_VOID_P' \
+    'CMAKE_LIBRARY_ARCHITECTURE' \
+    'CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES' \
+    'CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES' \
+    'CMAKE_SKIP_RPATH' \
+    'CMAKE_C_COMPILER' \
+    'CMAKE_CXX_COMPILER' \
+    'compat-glibc-shims.o' \
+    'fontconfig/2.15.0' \
+    '--remote=conancenter' \
+    'tools.build:sharedlinkflags' \
+    'tools.build:exelinkflags' \
+    'GIT_CONFIG_GLOBAL' \
+    'ccache' \
+    '-vv' \
+    'core.sources:download_cache' \
+    'core.sources:download_urls' \
+    'conan cache clean' \
+    'qtmultimedia=True' \
+    'qtwayland=False' \
+    'with_egl=True' \
+    'with_x11=True' \
+    'with_dbus=False' \
+    'BUILD_SHARED_LIBS=OFF' \
+    'CMAKE_PROJECT_INCLUDE' \
+    'verify-konsole-artifact.sh' \
+    'audit-with-hygiene-waivers.sh'; do
+    if ! grep -Fq -- "$needle" "$PLAN" &&
+       ! grep -Fq -- "$needle" "$REPO_ROOT/contrib/konsole/kde-builder.yaml.in"; then
+        fail "plan/config is missing: $needle"
+    fi
+done
+pass 'Zig baseline, static Qt, cache, hook and artifact gates are in the plan'
+
+if grep -Eq 'go( |$)|setup-go|go build|go test' "$PLAN"; then
+    fail 'Konsole plan unexpectedly contains a Go step'
+fi
+pass 'Konsole plan has no Go dependency'
+
+if grep -Eiq 'qt-install-dir|find_package\(Qt6' \
+    "$REPO_ROOT/contrib/konsole/kde-builder.yaml.in" "$PLAN"; then
+    fail 'configuration appears to opt into host Qt/KF6'
+fi
+pass 'kde-builder configuration does not opt into host Qt/KF6'
+
+workflow="$REPO_ROOT/.github/workflows/konsole-zig-build.yml"
+sed -e "s|@KDE_SOURCE_DIR@|$REPO_ROOT/.konsole-preflight-source|g" \
+    -e "s|@KDE_BUILD_DIR@|$REPO_ROOT/.konsole-preflight-build|g" \
+    -e "s|@KDE_INSTALL_DIR@|$REPO_ROOT/.konsole-preflight-install|g" \
+    -e "s|@KDE_LOG_DIR@|$REPO_ROOT/.konsole-preflight-logs|g" \
+    -e "s|@KDE_STATE_DIR@|$REPO_ROOT/.konsole-preflight-state|g" \
+    -e "s|@KDE_JOBS@|2|g" \
+    -e "s|@CONAN_TOOLCHAIN@|$REPO_ROOT/.konsole-preflight-qt/conan_toolchain.cmake|g" \
+    -e "s|@ZIGCC@|$REPO_ROOT/onebin/toolchain/zig-cc|g" \
+    -e "s|@ZIGCXX@|$REPO_ROOT/onebin/toolchain/zig-c++|g" \
+    -e "s|@CMAKE_PREFIX_PATH@|$REPO_ROOT/.konsole-preflight-qt;$REPO_ROOT/.konsole-preflight-install|g" \
+    -e "s|@PROJECT_INCLUDE@|$REPO_ROOT/contrib/konsole/project-include.cmake|g" \
+    -e "s|@KONSOLE_REF@|$(awk '$1 == "konsole" { print $2 }' "$REPO_ROOT/contrib/konsole/deps.lock")|g" \
+    "$REPO_ROOT/contrib/konsole/kde-builder.yaml.in" >"$RENDERED"
+python3 - "$RENDERED" "$workflow" <<'PY'
+import pathlib
+import sys
+import yaml
+
+config = yaml.safe_load(pathlib.Path(sys.argv[1]).read_text())
+assert config["config-version"] == 2
+assert config["global"]["include-dependencies"] is True
+assert config["global"]["num-cores"] == "2"
+assert "BUILD_SHARED_LIBS=OFF" in config["global"]["cmake-options"]
+assert "CMAKE_IGNORE_PREFIX_PATH=/usr;/lib;/lib64" in config["global"]["cmake-options"]
+assert config["override konsole"]["revision"]
+workflow = yaml.safe_load(pathlib.Path(sys.argv[2]).read_text())
+assert set(workflow["jobs"]) == {"preflight", "build"}
+print("YAML config/workflow parse: PASS")
+PY
+pass 'rendered kde-builder YAML and workflow parse'
+
+grep -Fq 'libGL.so*' "$REPO_ROOT/tools/verify-konsole-artifact.sh" || \
+    fail 'artifact verifier does not reject a hard libGL dependency'
+pass 'artifact verifier rejects a hard libGL dependency'
+
+for needle in \
+    'workflow_dispatch:' \
+    'timeout-minutes: 300' \
+    'actions/cache/restore@v4' \
+    'actions/cache/save@v4' \
+    'actions/checkout@v4' \
+    'make -C onebin' \
+    'Free disk space on the runner' \
+    'failure() || cancelled()' \
+    'set -o pipefail' \
+    'tee /tmp/build-output.log' \
+    'xvfb' \
+    'run-konsole-smoke.sh' \
+    'Scan Konsole sources for newer glibc symbols'; do
+    grep -Fq "$needle" "$workflow" || fail "workflow is missing: $needle"
+done
+if grep -Eiq 'setup-go|go build|go test' "$workflow"; then
+    fail 'workflow unexpectedly contains a Go step'
+fi
+pass 'workflow preserves f4 CI gates and has no Go setup'
+
+python3 -m py_compile "$REPO_ROOT/contrib/konsole/qt-host/conanfile.py"
+pass 'Conan recipe parses as Python'
+
+if command -v shellcheck >/dev/null 2>&1; then
+    shellcheck "$REPO_ROOT/tools/build-konsole.sh" "$REPO_ROOT/tools/run-konsole-smoke.sh" \
+        "$REPO_ROOT/tools/verify-konsole-artifact.sh"
+    pass 'shellcheck passed'
+else
+    printf 'SKIP: shellcheck is not installed\n'
+fi
+printf 'Konsole preflight: PASS\n'

--- a/tools/run-konsole-smoke.sh
+++ b/tools/run-konsole-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    printf 'usage: %s KONSOLE_BINARY OUTPUT_DIR\n' "$0" >&2
+    exit 2
+fi
+binary=$1
+out=$2
+mkdir -p "$out"
+display=${DISPLAY:-:99}
+server_log="$out/xvfb.log"
+app_log="$out/konsole.log"
+render_log="$out/render.log"
+png="$out/konsole-window.png"
+[[ -x $binary ]] || { printf 'error: missing Konsole: %s\n' "$binary" >&2; exit 1; }
+
+Xvfb "$display" -screen 0 1280x900x24 -ac +extension GLX +render -noreset >"$server_log" 2>&1 &
+xvfb_pid=$!
+app_pid=
+cleanup() {
+    [[ -n ${app_pid:-} ]] && kill "$app_pid" 2>/dev/null || true
+    [[ -n ${app_pid:-} ]] && wait "$app_pid" 2>/dev/null || true
+    kill "$xvfb_pid" 2>/dev/null || true
+    wait "$xvfb_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in {1..60}; do
+    xdpyinfo -display "$display" >/dev/null 2>&1 && break
+    sleep 1
+done
+xdpyinfo -display "$display" >/dev/null 2>&1 || {
+    printf 'error: Xvfb did not become ready\n' >&2
+    exit 1
+}
+
+install_dir=${KONSOLE_INSTALL_DIR:-$(cd "$(dirname "$binary")/.." && pwd)}
+runtime_dir="$out/xdg-runtime"
+mkdir -p "$runtime_dir"
+chmod 700 "$runtime_dir"
+export DISPLAY="$display"
+export XDG_RUNTIME_DIR="$runtime_dir"
+export XDG_DATA_DIRS="$install_dir/share:/usr/share"
+export QT_QPA_PLATFORM=xcb
+export LD_LIBRARY_PATH="$install_dir/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LIBGL_ALWAYS_SOFTWARE=1
+export SE_RENDER_DEBUG_FILE="$render_log"
+
+"$binary" --separate --nofork --hold >"$app_log" 2>&1 &
+app_pid=$!
+window_id=
+for _ in {1..60}; do
+    window_id=$(xdotool search --onlyvisible --pid "$app_pid" 2>/dev/null | head -n 1 || true)
+    [[ -n $window_id ]] && break
+    if ! kill -0 "$app_pid" 2>/dev/null; then
+        cat "$app_log" >&2 || true
+        printf 'error: Konsole exited before creating a window\n' >&2
+        exit 1
+    fi
+    sleep 1
+done
+[[ -n $window_id ]] || {
+    cat "$app_log" >&2 || true
+    printf 'error: no visible Konsole window\n' >&2
+    exit 1
+}
+
+xwd -display "$display" -id "$window_id" -silent >"$out/window.xwd"
+convert "$out/window.xwd" "$out/window.png"
+xwd -display "$display" -root -silent >"$out/screen.xwd"
+convert "$out/screen.xwd" "$png"
+dimensions=$(identify -format '%wx%h' "$png")
+[[ $dimensions == 1280x900 ]] || {
+    printf 'error: screenshot size %s\n' "$dimensions" >&2
+    exit 1
+}
+deviation=$(convert "$png" -format '%[standard-deviation]' info:)
+[[ $deviation != 0 && $deviation != 0.0* ]] || {
+    printf 'error: screenshot is blank\n' >&2
+    exit 1
+}
+if grep -Eiq 'Could not find the Qt platform plugin|cannot connect to display|failed to initialize graphics backend|no xcb' "$app_log"; then
+    cat "$app_log" >&2
+    printf 'error: graphical startup failure in log\n' >&2
+    exit 1
+fi
+printf 'Konsole graphical smoke: PASS (%s, pixel stddev %s)\n' "$dimensions" "$deviation"

--- a/tools/verify-konsole-artifact.sh
+++ b/tools/verify-konsole-artifact.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -x $1 ]]; then
+    printf 'usage: %s EXECUTABLE\n' "$0" >&2
+    exit 2
+fi
+
+binary=$1
+needed=$(readelf -d "$binary" | sed -n 's/.*Shared library: \[\([^]]*\)\].*/\1/p')
+printf 'DT_NEEDED for %s:\n%s\n' "$binary" "${needed:-<none>}"
+while IFS= read -r soname; do
+    [[ -z $soname ]] && continue
+    case $soname in
+        libQt6*.so*|libKF5*.so*|libKF6*.so*|libKDE*.so*)
+            printf 'error: host Qt/KDE library escaped: %s\n' "$soname" >&2
+            exit 1
+            ;;
+        libGL.so*|libGLX.so*|libOpenGL.so*)
+            printf 'error: OpenGL is a hard dependency: %s\n' "$soname" >&2
+            exit 1
+            ;;
+        libc.so.6|libdl.so.2|libpthread.so.0|libm.so.6|libgcc_s.so.1|\
+        libX11.so.6|libX11-xcb.so.1|libxcb.so.1|libxcb-cursor.so.0|\
+        libxcb-icccm.so.4|libxcb-image.so.0|libxcb-keysyms.so.1|\
+        libxcb-randr.so.0|libxcb-render.so.0|libxcb-render-util.so.0|\
+        libxcb-shape.so.0|libxcb-shm.so.0|libxcb-sync.so.1|\
+        libxcb-xfixes.so.0|libxcb-xkb.so.1|libICE.so.6|libSM.so.6)
+            ;;
+        *)
+            printf 'error: undeclared dynamic dependency: %s\n' "$soname" >&2
+            exit 1
+            ;;
+    esac
+done <<< "$needed"
+
+string_table=$(strings "$binary")
+grep -q 'QXcbIntegrationPlugin' <<< "$string_table" || {
+    printf 'error: qxcb static plugin is absent\n' >&2
+    exit 1
+}
+grep -Eq 'QXcb(Glx|Egl)IntegrationPlugin' <<< "$string_table" || {
+    printf 'error: qxcb GL integration plugin is absent\n' >&2
+    exit 1
+}
+printf 'Konsole artifact contract: PASS (static Qt/KF6, host X11/OpenGL ABI only)\n'


### PR DESCRIPTION
Добавляет отдельный manual GitHub Actions workflow для сборки и запуска Konsole в гибридной схеме по рецепту f4 qt: Qt и KF6 собираются из исходников Zig/Conan/kde-builder, хостовыми остаются только X11/xcb и OpenGL ABI. В workflow есть быстрый preflight, кэширование, диагностика, статический audit и Xvfb smoke-тест с PNG окна.

Локально после двух сверок рецепта: preflight PASS; 273 onebin tests passed, 0 failed, 3 skipped. Полный Qt/KF6 build намеренно оставлен GitHub Actions.